### PR TITLE
Remove `ray()` call from NovaImpersonatingBanner.php

### DIFF
--- a/src/Livewire/NovaImpersonatingBanner.php
+++ b/src/Livewire/NovaImpersonatingBanner.php
@@ -33,8 +33,6 @@ class NovaImpersonatingBanner extends Component
         app(ImpersonatesUsers::class)
             ->stopImpersonating(request(), Auth::guard('web'), User::class);
 
-        ray('stopImpersonating');
-
         return redirect(config('nova.impersonation.stopped', request()->header('Referer')));
     }
 }


### PR DESCRIPTION
Remove call to `ray()` to prevent errors when deploying to environments without Ray installed.